### PR TITLE
chore: Add libz-sys to Cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,7 @@ dependencies = [
  "clap",
  "dotenv",
  "git2",
+ "libz-sys",
  "regex",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ edition = "2021"
 clap = { version = "4.4.16", features = ["derive", "env"] }
 dotenv = "0.15.0"
 git2 = { version = "0.18.1", features = ["vendored-libgit2", "vendored-openssl", "zlib-ng-compat"] }
+libz-sys = "1.1.14"
 regex = "1.10.2"


### PR DESCRIPTION
Add `libz-sys@v1.1.14` to Cargo dependencies.

To support build errors that occur in specific environments.

```
...
error: failed to run custom build command for `libz-sys v1.1.14`

Caused by:
  process didn't exit successfully: `/Users/ef4b3f/workspace/github/semver-ci/target/debug/build/libz-sys-6e93b55cd4ca9a60/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=LIBZ_SYS_STATIC
  cargo:rerun-if-changed=build.rs
  CMAKE_TOOLCHAIN_FILE_aarch64-apple-darwin = None
  CMAKE_TOOLCHAIN_FILE_aarch64_apple_darwin = None
  HOST_CMAKE_TOOLCHAIN_FILE = None
  CMAKE_TOOLCHAIN_FILE = None
  CMAKE_GENERATOR_aarch64-apple-darwin = None
  CMAKE_GENERATOR_aarch64_apple_darwin = None
  HOST_CMAKE_GENERATOR = None
  CMAKE_GENERATOR = None
  CMAKE_PREFIX_PATH_aarch64-apple-darwin = None
  CMAKE_PREFIX_PATH_aarch64_apple_darwin = None
  HOST_CMAKE_PREFIX_PATH = None
  CMAKE_PREFIX_PATH = None
  CMAKE_aarch64-apple-darwin = None
  CMAKE_aarch64_apple_darwin = None
  HOST_CMAKE = None
  CMAKE = None
  running: cd "/Users/ef4b3f/workspace/github/semver-ci/target/debug/build/libz-sys-efaca97d2e0c49e7/out/build" && CMAKE_PREFIX_PATH="" "cmake" "/Users/ef4b3f/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libz-sys-1.1.14/src/zlib-ng" "-DCMAKE_OSX_ARCHITECTURES=arm64" "-DBUILD_SHARED_LIBS=OFF" "-DZLIB_COMPAT=ON" "-DZLIB_ENABLE_TESTS=OFF" "-DWITH_GZFILEOP=ON" "-DCMAKE_INSTALL_PREFIX=/Users/ef4b3f/workspace/github/semver-ci/target/debug/build/libz-sys-efaca97d2e0c49e7/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -arch arm64" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -arch arm64" "-DCMAKE_CXX_COMPILER=/usr/bin/c++" "-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -fPIC -arch arm64" "-DCMAKE_ASM_COMPILER=/usr/bin/cc" "-DCMAKE_BUILD_TYPE=Debug"

  --- stderr
  thread 'main' panicked at /Users/ef4b3f/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cmake-0.1.50/src/lib.rs:1098:5:

  failed to execute command: No such file or directory (os error 2)
  is `cmake` not installed?

  build script failed, must exit now
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```