### PR TITLE
fix: Find last tag sorted by semantic version in tag names

### DIFF
--- a/src/commands/version_command.rs
+++ b/src/commands/version_command.rs
@@ -37,7 +37,7 @@ pub(crate) fn run(args: VersionCommandArgs) {
 }
 
 fn version(scope: String, last_tag: String) -> String {
-    let mut semantic_version = SemanticVersion::from_string(last_tag[1..].to_string())
+    let mut semantic_version = SemanticVersion::from_string(last_tag.clone())
         .unwrap_or_else(|e| panic!("{}: {}", e, last_tag));
 
     semantic_version.increase_by_scope(scope).to_string(true)

--- a/src/semantic_version.rs
+++ b/src/semantic_version.rs
@@ -1,7 +1,25 @@
+use std::cmp::Ordering;
+
+#[derive(Eq, PartialEq, Debug)]
 pub struct SemanticVersion {
     pub major: u64,
     pub minor: u64,
     pub patch: u64,
+}
+
+impl PartialOrd for SemanticVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SemanticVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.major
+            .cmp(&other.major)
+            .then_with(|| self.minor.cmp(&other.minor))
+            .then_with(|| self.patch.cmp(&other.patch))
+    }
 }
 
 impl SemanticVersion {
@@ -34,7 +52,12 @@ impl SemanticVersion {
     }
 
     pub fn from_string(version_string: String) -> Result<Self, String> {
-        let parts: Vec<&str> = version_string.split('.').collect();
+        let prefix_stripped = match version_string.strip_prefix('v') {
+            Some(stripped) => stripped.to_string(),
+            None => version_string,
+        };
+
+        let parts: Vec<&str> = prefix_stripped.split('.').collect();
 
         if parts.len() != 3 {
             return Err("Invalid version string format".to_string());


### PR DESCRIPTION
Fix v0.9.0 being selected when v0.9.0, v0.10.0