### PR TITLE
feat: Exclude commits that meet certain conditions from the commit list in changes

### DIFF
--- a/src/pipelines/gitlab_ci.rs
+++ b/src/pipelines/gitlab_ci.rs
@@ -55,8 +55,8 @@ impl Pipeline for GitlabCI {
         let description = self.release_notes(
             release.description.clone(),
             release.generate_release_notes,
-            release.previous_tag.clone(),
-            config::env_var("CI_COMMIT_SHA"),
+            &release.previous_tag,
+            &config::env_var("CI_COMMIT_SHA"),
         );
 
         let mut body = HashMap::new();
@@ -78,13 +78,7 @@ impl GitlabCI {
             .unwrap_or_else(|e| panic!("{}", e));
     }
 
-    fn release_notes(
-        &self,
-        prepend: String,
-        auto_generate: bool,
-        from: String,
-        to: String,
-    ) -> String {
+    fn release_notes(&self, prepend: String, auto_generate: bool, from: &str, to: &str) -> String {
         let mut notes = prepend.clone();
 
         if auto_generate {
@@ -94,7 +88,7 @@ impl GitlabCI {
         notes
     }
 
-    fn compare(&self, from: String, to: String) -> String {
+    fn compare(&self, from: &str, to: &str) -> String {
         let url = format!(
             "{}/projects/{}/repository/compare",
             config::env_var("CI_API_V4_URL"),
@@ -108,8 +102,8 @@ impl GitlabCI {
         );
 
         let mut query = HashMap::new();
-        query.insert("from", from.as_str());
-        query.insert("to", to.as_str());
+        query.insert("from", from);
+        query.insert("to", to);
 
         let parsed = http_service::get(url, Some(headers), Some(query));
         let commits = self.collect_commits(&parsed);

--- a/src/pipelines/gitlab_ci.rs
+++ b/src/pipelines/gitlab_ci.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 pub(crate) struct GitlabCI;
 
 pub const GITLAB_CI: &str = "GITLAB_CI";
-const IGNORE_CHANGE_PREFIXES: [&str; 4] = ["refactor:", "style:", "test:", "chore:"];
+const IGNORE_CHANGE_PREFIXES: [&str; 5] = ["refactor:", "style:", "test:", "chore:", "Merge "];
 
 impl Pipeline for GitlabCI {
     fn init(&self) {

--- a/src/pipelines/gitlab_ci.rs
+++ b/src/pipelines/gitlab_ci.rs
@@ -113,7 +113,12 @@ impl GitlabCI {
 
         let parsed = http_service::get(url, Some(headers), Some(query));
         let commits = self.collect_commits(&parsed);
-        let full_diff = parsed.get("web_url").unwrap().as_str().unwrap_or("");
+        let empty_string_value = Value::String("".to_string());
+        let full_diff = parsed
+            .get("web_url")
+            .unwrap_or(&empty_string_value)
+            .as_str()
+            .unwrap_or("");
 
         format!(
             r#"## What's Changed


### PR DESCRIPTION
- When writing GitLab release notes
- Exclude commits that match semantic commit messages such as ["refactor:", "style:", "test:", "chore:"].