### PR TITLE
fix: CI_COMMIT_REF_NAME should be used in GitLab CI merge pipeline

### DIFF
--- a/src/pipelines/gitlab_ci.rs
+++ b/src/pipelines/gitlab_ci.rs
@@ -20,7 +20,7 @@ impl Pipeline for GitlabCI {
     }
 
     fn branch_name(&self) -> String {
-        config::env_var("CI_COMMIT_BRANCH")
+        config::env_var("CI_COMMIT_REF_NAME")
     }
 
     fn short_commit_sha(&self) -> String {


### PR DESCRIPTION
- CI_COMIMIT_BRANCH is not defined in GitLab CI merge pipeline