### PR TITLE
fix: Allow release without prerelease tag; log warning

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Branch starategy
+Git flow
+
+# Semantic Commit Messages
+
+See how a minor change to your commit message style can make you a better programmer.
+
+Format: `<type>(<scope>): <subject>`
+
+`<scope>` is optional
+
+## Example
+
+```
+feat: add hat wobble
+^--^  ^------------^
+|     |
+|     +-> Summary in present tense.
+|
++-------> Type: chore, docs, feat, fix, refactor, style, or test.
+```
+
+More Examples:
+
+- `feat`: (new feature for the user, not a new feature for build script)
+- `fix`: (bug fix for the user, not a fix to a build script)
+- `docs`: (changes to the documentation)
+- `style`: (formatting, missing semi colons, etc; no production code change)
+- `refactor`: (refactoring production code, eg. renaming a variable)
+- `test`: (adding missing tests, refactoring tests; no production code change)
+- `chore`: (updating grunt tasks etc; no production code change)
+
+References:
+
+- https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716
+- https://www.conventionalcommits.org/
+- https://seesparkbox.com/foundry/semantic_commit_messages
+- http://karma-runner.github.io/1.0/dev/git-commit-msg.html

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,7 @@ target/
 # Jetbranins IDE
 .idea
 
+# Cursor
+.cursor
+
 .env

--- a/src/commands/version_command.rs
+++ b/src/commands/version_command.rs
@@ -53,13 +53,7 @@ pub(crate) fn run(args: VersionCommandArgs) -> Result<(), Box<dyn Error>> {
     let prerelease_stage = prerelease_stage(&pipeline_info.branch_name);
     // For release (main, master)
     if args.scope == "release" || prerelease_stage.is_empty() {
-        upcoming_version =
-            upcoming_official_version(&tag_names, &last_official_tag).map_err(|e| {
-                Box::new(DefaultError {
-                    message: "Cannot infer upcoming official version".to_string(),
-                    source: Some(e),
-                })
-            })?;
+        upcoming_version = upcoming_official_version(&tag_names, &last_official_tag);
         last_version = last_official_tag.to_string(true);
     // For pre-release (develop, feature/*, release/*, hotfix/*)
     } else {
@@ -105,23 +99,32 @@ fn prerelease_stage(branch_name: &str) -> String {
 fn upcoming_official_version(
     tag_names: &StringArray,
     last_official_version: &SemanticVersion,
-) -> Result<String, Box<dyn Error>> {
+) -> String {
     match git_service::last_tag_by_pattern(tag_names, SEMANTIC_VERSION_TAG_PRERELEASE_PATTERN, None)
     {
         Some(mut last_prerelease_tag) => match last_prerelease_tag.cmp(last_official_version) {
-            Ordering::Greater => Ok(last_prerelease_tag.release().to_string(true)),
-            _ => Err(Box::new(DefaultError {
-                message: format!(
-                    "There are no pre-release tags after last official tag({})",
+            Ordering::Greater => last_prerelease_tag.release().to_string(true),
+            _ => {
+                log::warn!(
+                    "No newer pre-release after last official tag ({}). Fallback to minor bump.",
                     last_official_version.to_string(true)
-                ),
-                source: None,
-            })),
+                );
+                last_official_version
+                    .clone()
+                    .increase_by_scope("minor".to_string())
+                    .to_string(true)
+            }
         },
-        None => Err(Box::new(DefaultError {
-            message: "Not found pre-release tags".to_string(),
-            source: None,
-        })),
+        None => {
+            log::warn!(
+                "No pre-release tags found. Fallback to minor bump from last official ({}).",
+                last_official_version.to_string(true)
+            );
+            last_official_version
+                .clone()
+                .increase_by_scope("minor".to_string())
+                .to_string(true)
+        }
     }
 }
 


### PR DESCRIPTION
- upcoming_official_version: return String; warn and minor-bump when no/newer prerelease missing
- version command: use simplified call; remove unnecessary error mapping
- chore: Add .github/CONTRIBUTING.md